### PR TITLE
DTSW-2826  porting docs unit B1

### DIFF
--- a/src/_images/assembly/road_tiles_assembly/instructions/3way_1_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/3way_1_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f0b45bf78411c0c1de56e48db3f195bb69ae342263c33e2ad469c26287a2ead
+size 4293200

--- a/src/_images/assembly/road_tiles_assembly/instructions/4way_1_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/4way_1_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee29ffad6faeaa39682ef0429f934718d080b4c273bc305427359bf2610dfc53
+size 9952183

--- a/src/_images/assembly/road_tiles_assembly/instructions/4way_2_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/4way_2_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0a86db5aef1dfd89ce5db9672530650dd3e9d4d3e413894f409697293d67cb6
+size 8750514

--- a/src/_images/assembly/road_tiles_assembly/instructions/4way_3_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/4way_3_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09a166ed1d2fd044ab3495af88b0b58a8c59bb3880dafe5b017b558b9adf2c13
+size 10430635

--- a/src/_images/assembly/road_tiles_assembly/instructions/4way_4_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/4way_4_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a163a98a944596bb5a9137b40eb8548a47672dbdd28cde7037083fd7edd643b
+size 9791228

--- a/src/_images/assembly/road_tiles_assembly/instructions/4way_5_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/4way_5_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e51ed51d2a5a7b89ecb7a6de76f0f56a2df62829b3d42d8a2693f4280be9602
+size 9500407

--- a/src/_images/assembly/road_tiles_assembly/instructions/4way_6_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/4way_6_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57cbb8475cf01f748ccd604d64b3e59eb91bcccf50d2d67bfeee7604a7678c2b
+size 8129886

--- a/src/_images/assembly/road_tiles_assembly/instructions/4way_7_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/4way_7_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:273f6e32f6bf0f5c338a8d220ad9d681792ab9ede41340dcba4899e3dc2f38d2
+size 10143566

--- a/src/_images/assembly/road_tiles_assembly/instructions/curved_1_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/curved_1_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a973056f093dac87b32f1f1defc8fd033d662b9ce9b11c6f74296667df2fbd8c
+size 9624415

--- a/src/_images/assembly/road_tiles_assembly/instructions/curved_2_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/curved_2_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d130c97808117b28d9643bf502069bade67042f390a2995d192ca2c865dcc75
+size 9342608

--- a/src/_images/assembly/road_tiles_assembly/instructions/curved_3_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/curved_3_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2c500c01c50d12d31a4ed4e9a09fe46ffc27c5b3b7e06f58c8ed11e25c2f2d4
+size 9084209

--- a/src/_images/assembly/road_tiles_assembly/instructions/curved_4_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/curved_4_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f67c4c0902141d61b500edfce8fe64c3a3b1ba96016afdf6b73ff8fe552fece
+size 14870359

--- a/src/_images/assembly/road_tiles_assembly/instructions/curved_5_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/curved_5_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:037a4d718b41dfef8195a21a3880cff4eeec1446b201274ac7084be1f352f82a
+size 10179702

--- a/src/_images/assembly/road_tiles_assembly/instructions/curved_6_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/curved_6_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d14b5a921d0dc043bbc350c33dc769453ee90c1600ea460f396798b118859ae4
+size 11411813

--- a/src/_images/assembly/road_tiles_assembly/instructions/curved_7_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/curved_7_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81211882235801c3af50684276e9ca5c568f70ab6ec21e0751c6a38e5d28731f
+size 8029260

--- a/src/_images/assembly/road_tiles_assembly/instructions/straight_1_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/straight_1_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8183c937c854fbcf86d055e356be23720d474d1835bfe0c241418c38d3f40438
+size 8009731

--- a/src/_images/assembly/road_tiles_assembly/instructions/straight_2_done.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/straight_2_done.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22abebbea19ca7c0fb350498c34acad8922af5c2e9df763af939fe2ca03c2e28
+size 8564588

--- a/src/_images/assembly/road_tiles_assembly/instructions/straight_3_done_arrows.png
+++ b/src/_images/assembly/road_tiles_assembly/instructions/straight_3_done_arrows.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e20076ee3860ad3744abf2e5369c248ca3a6805437a9b5755024bbad4c95404
+size 2877091

--- a/src/_toc.yml
+++ b/src/_toc.yml
@@ -22,3 +22,8 @@ parts:
             sections:
                 - file: part_2/chapter_c/section_1
                 - file: part_2/chapter_c/section_2
+    - caption: Assembly
+      maxdepth: 2
+      numbered: False
+      chapters:
+          - file: assembly/road_tiles_assembly/index

--- a/src/assembly/road_tiles_assembly/index.md
+++ b/src/assembly/road_tiles_assembly/index.md
@@ -1,0 +1,232 @@
+(dt-ops-tiles)=
+# Road Tiles Assembly
+
+```{needget}
+* Knowledge of the [Duckietown appearance specifications](#dt-ops-appearance-specifications)
+* Materials: tiles, white, yellow and red road markings
+* Tools: scissors (or a sharp cutter) and a ruler
+* Duckietown road tiles
+---
+* You will have tiles that comply to the Duckietown operation standards
+* You can move on to [Assembly of other components](#dt-ops-assembly)
+```
+
+## Before we begin 
+:::{tip}
+To ensure that your streets will last long, make sure to follow these: 
+* Clean the tiles with a cloth and some water and soap before attaching any tape.
+* Place the yellow tape on the tile and cut out pieces rather than pre-cutting them and attaching them to the tile as glue will be lost if you do not directly place them at the intended spot.   
+:::
+
+(dt-ops-tiles-straight)=
+## Straight roads
+
+Each straight road segment has:
+
+* Solid white markings on the outer sides of the lanes (right of direction of travel)
+* Dashed yellow markings at the center
+* Each lane is 21 cm wide (from end of white to beginning of yellow)
+
+### Assembly
+
+Start by placing the yellow tape in the middle of the tile as shown in {numref}`fig:tile_instruction_straight_1`.
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/straight_1_done.png
+:width: 100%
+:name: fig:tile_instruction_straight_1
+
+Placement of the yellow middle lane in the center of the tile.
+```
+
+Make sure that the yellow tape is properly centered on the tile. The tile has a nominal width of 57cm without the interlocking teeth.
+This means from the end of the yellow tape to the end of the tile there should be a distance of 27.25cm as can be seen in {numref}`fig:tile_instruction_straight_2`. 
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/straight_2_done.png
+:width: 100%
+:name: fig:tile_instruction_straight_2
+
+Measurement from end of the yellow tape to the edge of the tile.
+```
+
+Once you have placed the yellow tape, cut out pieces of 2.5cm each, starting 5cm from the outer edge of the tile without the interlocking teeth (as shown in {numref}`fig:tile_instruction_straight_3`).
+Next, place the white lane markings at the outer part of the tile in a distance of 21cm to the end of the yellow tape.
+The Result can be seen in {numref}`fig:tile_instruction_straight_3`.  
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/straight_3_done_arrows.png
+:width: 100%
+:name: fig:tile_instruction_straight_3
+
+Finished straight road segment with measurements.
+```
+
+(dt-ops-tiles-curves)=
+## Curved roads
+
+Each curved road segment has:
+
+ * Solid white markings on the outer sides of the lanes (right of direction of travel)
+ * Dashed yellow markings at the center
+ * Each lane is 21 cm wide (from end of white to beginning of yellow)
+ 
+### Assembly 
+
+If you have a laser cutter available, you can use the provided file from [here](https://github.com/duckietown/docs-opmanual_duckietown/tree/daffy/book/opmanual_duckietown/TileTemplates/CurvedTileTemplate) to laser cut the template shown below. 
+
+If you do not have access to a laser cutter, you have to create the middle line by hand. One way to do it is to take a string, place one end in the outer edge of the tile (excluding the interlocking teeth) and make small markings in the form of a quarter circle in a distance of 27.25cm.
+This represents the inner border of where you have to put the yellow tape. The length of the single tape pieces is 5cm as for the straight road segment. For more detailed measurements, refer to {numref}`fig:curved`.
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/curved_1_done.png
+:width: 100%
+:name: fig:tile_instruction_curved_1
+
+Placement of the yellow tape.
+```
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/curved_2_done.png
+:width: 100%
+:name: fig:tile_instruction_curved_2
+
+Measurement of lane width.
+```
+
+Once you have the middle of the lane in place, you are ready to add the inner white line of the road. Make sure that the lane width is 21cm.
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/curved_3_done.png
+:width: 100%
+:name: fig:tile_instruction_curved_3
+
+Measurement of lane width and white tape placement.
+```
+
+To add the outer white line you can either use another template from above or you will have to measure again. You can use the same technique as for the yellow middle line: place one end of a rope in the edge of the tile and draw a quarter circle with a radius of 50.75cm which will represent the inner boundary of the white tape. 
+Alternatively, you can mark the lane width of 21cm at different locations and place the white tape accordingly.  
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/curved_4_done.png
+:width: 100%
+:name: fig:tile_instruction_curved_4
+
+Measurement of lane width.
+```
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/curved_5_done.png
+:width: 100%
+:name: fig:tile_instruction_curved_5
+
+Measurement of lane width.
+```
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/curved_6_done.png
+:width: 100%
+:name: fig:tile_instruction_curved_6
+
+Measurement of lane width.
+```
+
+The finished curved lane segment looks as in {numref}`fig:tile_instruction_curved_7`
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/curved_7_done.png
+:width: 100%
+:name: fig:tile_instruction_curved_7
+
+Finished curved road segment.
+```
+
+(dt-ops-tiles-intersections)=
+## Intersections
+
+Each intersection road segment (3- or 4- way) has:
+
+ * Solid white markings on the outer sides of the lanes (right of direction of travel)
+ * Dashed yellow markings at the center
+ * Each lane is 21 cm wide (from end of white to beginning of yellow)
+ * Solid red markings as stop signs
+
+### Assembly of 4-way intersection
+
+First, place four yellow tape strips as shown in the pictures below. Make sure that they are centered on the tile and that they reach in 6cm from the beginning of the tile without the interlocking teeth. 
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/4way_1_done.png
+:width: 100%
+:name: fig:tile_instruction_4way_1
+
+Placement of the yellow tape.
+```
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/4way_2_done.png
+:width: 100%
+:name: fig:tile_instruction_4way_2
+
+Placement of the yellow tape.
+```
+
+Now place the red tape aligned to the yellow tape. Ensure that the red tape is horizontally aligned with the edge of the tile and 21cm long. 
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/4way_3_done.png
+:width: 100%
+:name: fig:tile_instruction_4way_3
+
+Placement of the red tape.
+```
+
+Repeat this for the other edges of the intersection. 
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/4way_4_done.png
+:width: 100%
+:name: fig:tile_instruction_4way_4
+
+Placement of the red tape for whole intersection.
+```
+
+Cut the yellow lane markings to a length of 5cm. 
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/4way_5_done.png
+:width: 100%
+:name: fig:tile_instruction_4way_5
+
+Yellow tape cut to 5cm length.
+```
+
+Finally, add the white tape on the sides. Do this for all the corners of the intersection. 
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/4way_6_done.png
+:width: 100%
+:name: fig:tile_instruction_4way_6
+
+Placement of the white tape.
+```
+
+The finished 4-way intersection lane segment looks as in {numref}`fig:tile_instruction_4way_7`
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/4way_7_done.png
+:width: 100%
+:name: fig:tile_instruction_4way_7
+
+Finished 4-way intersection road segment.
+```
+
+:::{tip}
+You don't have to cut out the edges of the interlocking teeth from the white tape. Just use the overlapping tape to connect the road segment to the surrounding tiles nicely. 
+:::
+
+### Assembly of 3-way intersection 
+
+3-way intersections are built the same way as 4-way intersections with the difference that on one edge white tape is placed instead of red and yellow. 
+The resulting 3-way intersection can be seen in {numref}`fig:tile_instruction_3way_1`. 
+
+```{figure} ../../_images/assembly/road_tiles_assembly/instructions/3way_1_done.png
+:width: 100%
+:name: fig:tile_instruction_3way_1
+
+Finished 3-way intersection road segment.
+```
+
+### Troubleshooting
+
+```{trouble}
+My tape tends to detach from the tiles. The glue is no good.
+---
+Make sure you follow these steps:
+1. clean the tiles with a water and alcohol solution to remove residual oils before placing the tapes, and dry them completely
+2. apply the tape directly to the tiles and cut it on site, rather than using an intermediate medium
+3. use a heat source, e.g., a hair dryer, to warm up the tape after the first application. The objective is to soften the glue. Once back to room temperature, the stickyness will be much improved.
+```


### PR DESCRIPTION
Following section is taken from the old docs to jupyter book docs:
* Unit B-1: Road tiles assembly

The relevant _toc.yml changes:
![image](https://user-images.githubusercontent.com/10885835/223866907-3c68e3f8-2cf9-4ca0-b0bd-001d488297aa.png)

The compiled unit (rough view):
![book-opmanual-duckietown_html_assembly_road_tiles_assembly_index html_30](https://user-images.githubusercontent.com/10885835/223867164-e01c1f92-5403-472d-93d1-bf7d6caf805b.png)
